### PR TITLE
Adding state parameter support for Date::Holidays::DE

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 sudo: false
 language: perl
 perl:
-- '5.24'
-- '5.22'
+- '5.26'
 - '5.20'
-- '5.10'
 before_install:
 - git config --global user.name "TravisCI"
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
   HARNESS_TIMER=1
 - dzil listdeps | grep -vP '[^\w:]' | cpanm --quiet --notest --skip-satisfied
 script:
-- dzil smoke --release --author
+- dzil smoke --release --author 2> /dev/null
 after_success:
 - dzil cover -outputdir cover_db -report coveralls
 notifications:

--- a/Changes
+++ b/Changes
@@ -1,5 +1,13 @@
 Changes file for Date-Holidays
 
+1.17 2019-01-22 Feature release, update recommended
+
+- Improved adapter for:
+    Date::Holidays::DE we now support the state parameter for this distribution
+
+    Ref: https://github.com/jonasbn/Date-Holidays/issues/31
+
+
 1.16 2018-06-17 Feature release, update recommended
 
 - Added adapter for:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Date::Holidays - Date::Holidays::\* adapter and aggregator for all your holiday 
 
 # VERSION
 
-The documentation describes version 1.16 of Date::Holidays
+The documentation describes version 1.17 of Date::Holidays
 
 # FEATURES
 
@@ -209,7 +209,7 @@ it tries is\_&lt;countrycode>\_holiday.
 Takes 6 optional named arguments:
 
 - year, four digit parameter representing year
-- month, 1.16, representing month
+- month, 1.17, representing month
 - day, 1-31, representing day
 - countries (OPTIONAL), a list of ISO3166 country codes
 - state, ISO-3166-2 code for a state. Not all countries support this parameter
@@ -482,6 +482,7 @@ all the wrapped (adapted and aggregated) distributions.
 
 # ACKNOWLEDGEMENTS
 
+- Mario Minati, for telling me about the states in Date::Holidays::DE resulting in 1.17
 - Vladimir Varlamov, PR introducing Date::Holidays::KZ resulting in 1.07
 - CHORNY (Alexandr Ciornii), Github issue #10, letting me know I included local/ by accident,
 resulting in release 1.05
@@ -508,7 +509,7 @@ Jonas B. Nielsen, (jonasbn) - `<jonasbn@cpan.org>`
 # LICENSE AND COPYRIGHT
 
 Date-Holidays and related modules are (C) by Jonas B. Nielsen, (jonasbn)
-2004-2018
+2004-2019
 
 Date-Holidays and related modules are released under the Artistic License 2.0
 

--- a/lib/Date/Holidays.pm
+++ b/lib/Date/Holidays.pm
@@ -12,7 +12,7 @@ use Scalar::Util qw(blessed);
 
 use base 'Date::Holidays::Adapter';
 
-$VERSION = '1.16';
+$VERSION = '1.17';
 
 sub new {
     my ( $class, %params ) = @_;
@@ -313,7 +313,7 @@ Date::Holidays - Date::Holidays::* adapter and aggregator for all your holiday n
 
 =head1 VERSION
 
-The documentation describes version 1.16 of Date::Holidays
+The documentation describes version 1.17 of Date::Holidays
 
 =head1 FEATURES
 
@@ -527,7 +527,7 @@ Takes 6 optional named arguments:
 
 =item * year, four digit parameter representing year
 
-=item * month, 1.16, representing month
+=item * month, 1.17, representing month
 
 =item * day, 1-31, representing day
 
@@ -898,6 +898,8 @@ all the wrapped (adapted and aggregated) distributions.
 
 =over
 
+=item * Mario Minati, for telling me about the states in Date::Holidays::DE resulting in 1.17
+
 =item * Vladimir Varlamov, PR introducing Date::Holidays::KZ resulting in 1.07
 
 =item * CHORNY (Alexandr Ciornii), Github issue #10, letting me know I included local/ by accident,
@@ -940,7 +942,7 @@ Jonas B. Nielsen, (jonasbn) - C<< <jonasbn@cpan.org> >>
 =head1 LICENSE AND COPYRIGHT
 
 Date-Holidays and related modules are (C) by Jonas B. Nielsen, (jonasbn)
-2004-2018
+2004-2019
 
 Date-Holidays and related modules are released under the Artistic License 2.0
 

--- a/lib/Date/Holidays/Adapter.pm
+++ b/lib/Date/Holidays/Adapter.pm
@@ -10,7 +10,7 @@ use Scalar::Util qw(blessed);
 
 use vars qw($VERSION);
 
-$VERSION = '1.16';
+$VERSION = '1.17';
 
 sub new {
     my ($class, %params) = @_;
@@ -277,7 +277,7 @@ Date::Holidays::Adapter - an adapter class for Date::Holidays::* modules
 
 =head1 VERSION
 
-This POD describes version 1.16 of Date::Holidays::Adapter
+This POD describes version 1.17 of Date::Holidays::Adapter
 
 =head1 SYNOPSIS
 
@@ -448,7 +448,7 @@ Jonas B. Nielsen, (jonasbn) - C<< <jonasbn@cpan.org> >>
 =head1 LICENSE AND COPYRIGHT
 
 L<Date::Holidays> and related modules are (C) by Jonas B. Nielsen, (jonasbn)
-2004-2018
+2004-2019
 
 Date-Holidays and related modules are released under the Artistic License 2.0
 

--- a/lib/Date/Holidays/Adapter/AU.pm
+++ b/lib/Date/Holidays/Adapter/AU.pm
@@ -6,7 +6,7 @@ use vars qw($VERSION);
 
 use base 'Date::Holidays::Adapter';
 
-$VERSION = '1.16';
+$VERSION = '1.17';
 
 use constant DEFAULT_STATE => 'VIC';
 
@@ -48,7 +48,7 @@ Date::Holidays::Adapter::AU - an adapter class for Date::Holidays::AU
 
 =head1 VERSION
 
-This POD describes version 1.16 of Date::Holidays::Adapter::AU
+This POD describes version 1.17 of Date::Holidays::Adapter::AU
 
 =head1 DESCRIPTION
 
@@ -113,7 +113,7 @@ Jonas B. Nielsen, (jonasbn) - C<< <jonasbn@cpan.org> >>
 =head1 LICENSE AND COPYRIGHT
 
 L<Date::Holidays> and related modules are (C) by Jonas B. Nielsen, (jonasbn)
-2004-2018
+2004-2019
 
 Date-Holidays and related modules are released under the Artistic License 2.0
 

--- a/lib/Date/Holidays/Adapter/BR.pm
+++ b/lib/Date/Holidays/Adapter/BR.pm
@@ -7,7 +7,7 @@ use base 'Date::Holidays::Adapter';
 
 use vars qw($VERSION);
 
-$VERSION = '1.16';
+$VERSION = '1.17';
 
 sub holidays {
     my ( $self, %params ) = @_;
@@ -46,7 +46,7 @@ Date::Holidays::Adapter::BR - an adapter class for Date::Holidays::BR
 
 =head1 VERSION
 
-This POD describes version 1.16 of Date::Holidays::Adapter::BR
+This POD describes version 1.17 of Date::Holidays::Adapter::BR
 
 =head1 DESCRIPTION
 
@@ -108,7 +108,7 @@ Jonas B. Nielsen, (jonasbn) - C<< <jonasbn@cpan.org> >>
 =head1 LICENSE AND COPYRIGHT
 
 L<Date::Holidays> and related modules are (C) by Jonas B. Nielsen, (jonasbn)
-2004-2018
+2004-2019
 
 Date-Holidays and related modules are released under the Artistic License 2.0
 

--- a/lib/Date/Holidays/Adapter/BY.pm
+++ b/lib/Date/Holidays/Adapter/BY.pm
@@ -6,7 +6,7 @@ use vars qw($VERSION);
 
 use base 'Date::Holidays::Adapter';
 
-$VERSION = '1.16';
+$VERSION = '1.17';
 
 sub holidays {
     my ($self, %params) = @_;
@@ -48,7 +48,7 @@ Date::Holidays::Adapter::BY - an adapter class for Date::Holidays::BY
 
 =head1 VERSION
 
-This POD describes version 1.16 of Date::Holidays::Adapter::BY
+This POD describes version 1.17 of Date::Holidays::Adapter::BY
 
 =head1 DESCRIPTION
 
@@ -110,7 +110,7 @@ Jonas B. Nielsen, (jonasbn) - C<< <jonasbn@cpan.org> >>
 =head1 LICENSE AND COPYRIGHT
 
 L<Date::Holidays> and related modules are (C) by Jonas B. Nielsen, (jonasbn)
-2004-2018
+2004-2019
 
 Date-Holidays and related modules are released under the Artistic License 2.0
 

--- a/lib/Date/Holidays/Adapter/CA_ES.pm
+++ b/lib/Date/Holidays/Adapter/CA_ES.pm
@@ -7,7 +7,7 @@ use base qw(Date::Holidays::Adapter::ES);
 
 use vars qw($VERSION);
 
-$VERSION = '1.16';
+$VERSION = '1.17';
 
 1;
 
@@ -21,7 +21,7 @@ Date::Holidays::Adapter::CA_ES - adapter dummy class for Date::Holidays::CA_ES
 
 =head1 VERSION
 
-This POD describes version 1.16 of Date::Holidays::Adapter::CA_ES
+This POD describes version 1.17 of Date::Holidays::Adapter::CA_ES
 
 =head1 SYNOPSIS
 
@@ -99,7 +99,7 @@ Jonas B. Nielsen, (jonasbn) - C<< <jonasbn@cpan.org> >>
 =head1 LICENSE AND COPYRIGHT
 
 L<Date::Holidays> and related modules are (C) by Jonas B. Nielsen, (jonasbn)
-2004-2018
+2004-2019
 
 Date-Holidays and related modules are released under the Artistic License 2.0
 

--- a/lib/Date/Holidays/Adapter/CN.pm
+++ b/lib/Date/Holidays/Adapter/CN.pm
@@ -7,7 +7,7 @@ use base 'Date::Holidays::Adapter';
 
 use vars qw($VERSION);
 
-$VERSION = '1.16';
+$VERSION = '1.17';
 
 sub holidays {
     my ($self, %params) = @_;
@@ -45,7 +45,7 @@ Date::Holidays::Adapter::CN - an adapter class for Date::Holidays::CN
 
 =head1 VERSION
 
-This POD describes version 1.16 of Date::Holidays::Adapter::CN
+This POD describes version 1.17 of Date::Holidays::Adapter::CN
 
 =head1 DESCRIPTION
 
@@ -109,7 +109,7 @@ Jonas B. Nielsen, (jonasbn) - C<< <jonasbn@cpan.org> >>
 =head1 LICENSE AND COPYRIGHT
 
 L<Date::Holidays> and related modules are (C) by Jonas B. Nielsen, (jonasbn)
-2004-2018
+2004-2019
 
 Date-Holidays and related modules are released under the Artistic License 2.0
 

--- a/lib/Date/Holidays/Adapter/CZ.pm
+++ b/lib/Date/Holidays/Adapter/CZ.pm
@@ -7,7 +7,7 @@ use base 'Date::Holidays::Adapter';
 
 use vars qw($VERSION);
 
-$VERSION = '1.16';
+$VERSION = '1.17';
 
 my $format = '%#:%m%d';
 
@@ -87,7 +87,7 @@ Date::Holidays::Adapter::CZ - an adapter class for Date::Holidays::CZ
 
 =head1 VERSION
 
-This POD describes version 1.16 of Date::Holidays::Adapter::CZ
+This POD describes version 1.17 of Date::Holidays::Adapter::CZ
 
 =head1 DESCRIPTION
 
@@ -157,7 +157,7 @@ Jonas B. Nielsen, (jonasbn) - C<< <jonasbn@cpan.org> >>
 =head1 LICENSE AND COPYRIGHT
 
 L<Date::Holidays> and related modules are (C) by Jonas B. Nielsen, (jonasbn)
-2004-2018
+2004-2019
 
 Date-Holidays and related modules are released under the Artistic License 2.0
 

--- a/lib/Date/Holidays/Adapter/DE.pm
+++ b/lib/Date/Holidays/Adapter/DE.pm
@@ -163,6 +163,9 @@ B<countrycode> in the call to the constructor B<new>.
 The calendar will spand for a year and the keys consist of B<month> and B<day>
 concatenated.
 
+In addition from version 1.17 the adapter support the B<state> parameter, defaulting to
+B<'all'>.
+
 =head1 DIAGNOSTICS
 
 Please refer to DIAGNOSTICS in L<Date::Holidays>

--- a/lib/Date/Holidays/Adapter/DE.pm
+++ b/lib/Date/Holidays/Adapter/DE.pm
@@ -10,7 +10,7 @@ use vars qw($VERSION);
 
 my $format = '%#:%m%d';
 
-$VERSION = '1.16';
+$VERSION = '1.17';
 
 # Lifted from Date::Holidays::DE example: feiertage.pl
 # Ref: https://metacpan.org/source/MSCHMITT/Date-Holidays-DE-1.9/example/feiertage.pl
@@ -53,29 +53,43 @@ my %holiday_names = (
 sub holidays {
     my ($self, %params) = @_;
 
+    my $state = $params{'state'} ? $params{'state'} : ['all'];
+
+    use Data::Dumper;
+    print STDERR "We got state: ", Dumper $state;
+
+    my $holidays;
+
     if ( $params{'year'} ) {
-        $self->_transform_arrayref_to_hashref(
+        $holidays = $self->_transform_arrayref_to_hashref(
             Date::Holidays::DE::holidays(
                 YEAR   => $params{'year'},
                 FORMAT => $format,
+                WHERE  => $state,
             )
         );
     }
     else {
-        $self->_transform_arrayref_to_hashref(
+        $holidays = $self->_transform_arrayref_to_hashref(
             Date::Holidays::DE::holidays(
                 FORMAT => $format,
+                WHERE  => $state,
             )
         );
     }
+
+    return $holidays;
 }
 
 sub is_holiday {
     my ($self, %params) = @_;
 
+    my $state = $params{'state'} ? $params{'state'} : ['all'];
+
     my $holidays = Date::Holidays::DE::holidays(
         YEAR   => $params{'year'},
         FORMAT => $format,
+        WHERE  => $state,
     );
 
     my $holidays_hashref = $self->_transform_arrayref_to_hashref($holidays);
@@ -101,6 +115,8 @@ sub _transform_arrayref_to_hashref {
         $hashref_of_holidays->{$key} = $holiday_names{$shortname};
     }
 
+    print STDERR "We got state: ", Dumper $hashref_of_holidays;
+
     return $hashref_of_holidays;
 }
 
@@ -116,7 +132,7 @@ Date::Holidays::Adapter::DE - an adapter class for Date::Holidays::DE
 
 =head1 VERSION
 
-This POD describes version 1.16 of Date::Holidays::Adapter::DE
+This POD describes version 1.17 of Date::Holidays::Adapter::DE
 
 =head1 DESCRIPTION
 
@@ -186,7 +202,7 @@ Jonas B. Nielsen, (jonasbn) - C<< <jonasbn@cpan.org> >>
 =head1 LICENSE AND COPYRIGHT
 
 L<Date::Holidays> and related modules are (C) by Jonas B. Nielsen, (jonasbn)
-2004-2018
+2004-2019
 
 Date-Holidays and related modules are released under the Artistic License 2.0
 

--- a/lib/Date/Holidays/Adapter/DK.pm
+++ b/lib/Date/Holidays/Adapter/DK.pm
@@ -6,7 +6,7 @@ use vars qw($VERSION);
 
 use base 'Date::Holidays::Adapter';
 
-$VERSION = '1.16';
+$VERSION = '1.17';
 
 sub holidays {
     my ($self, %params) = @_;
@@ -44,7 +44,7 @@ Date::Holidays::Adapter::DK - an adapter class for Date::Holidays::DK
 
 =head1 VERSION
 
-This POD describes version 1.16 of Date::Holidays::Adapter::DK
+This POD describes version 1.17 of Date::Holidays::Adapter::DK
 
 =head1 DESCRIPTION
 
@@ -106,7 +106,7 @@ Jonas B. Nielsen, (jonasbn) - C<< <jonasbn@cpan.org> >>
 =head1 LICENSE AND COPYRIGHT
 
 L<Date::Holidays> and related modules are (C) by Jonas B. Nielsen, (jonasbn)
-2004-2018
+2004-2019
 
 Date-Holidays and related modules are released under the Artistic License 2.0
 

--- a/lib/Date/Holidays/Adapter/ES.pm
+++ b/lib/Date/Holidays/Adapter/ES.pm
@@ -8,7 +8,7 @@ use Module::Load; # load
 
 use vars qw($VERSION);
 
-$VERSION = '1.16';
+$VERSION = '1.17';
 
 sub holidays {
     my ($self, %params) = @_;
@@ -84,7 +84,7 @@ Date::Holidays::Adapter::ES - adapter class for Date::Holidays::ES and Date::Hol
 
 =head1 VERSION
 
-This POD describes version 1.16 of Date::Holidays::Adapter::ES
+This POD describes version 1.17 of Date::Holidays::Adapter::ES
 
 =head1 DESCRIPTION
 
@@ -166,7 +166,7 @@ Jonas B. Nielsen, (jonasbn) - C<< <jonasbn@cpan.org> >>
 =head1 LICENSE AND COPYRIGHT
 
 L<Date::Holidays> and related modules are (C) by Jonas B. Nielsen, (jonasbn)
-2004-2018
+2004-2019
 
 Date-Holidays and related modules are released under the Artistic License 2.0
 

--- a/lib/Date/Holidays/Adapter/FR.pm
+++ b/lib/Date/Holidays/Adapter/FR.pm
@@ -7,7 +7,7 @@ use Carp;
 
 use base 'Date::Holidays::Adapter';
 
-$VERSION = '1.16';
+$VERSION = '1.17';
 
 sub holidays {
     croak "holidays is unimplemented for ".__PACKAGE__;
@@ -37,7 +37,7 @@ Date::Holidays::Adapter::FR - an adapter class for Date::Holidays::FR
 
 =head1 VERSION
 
-This POD describes version 1.16 of Date::Holidays::Adapter::FR
+This POD describes version 1.17 of Date::Holidays::Adapter::FR
 
 =head1 DESCRIPTION
 
@@ -105,7 +105,7 @@ Jonas B. Nielsen, (jonasbn) - C<< <jonasbn@cpan.org> >>
 =head1 LICENSE AND COPYRIGHT
 
 L<Date::Holidays> and related modules are (C) by Jonas B. Nielsen, (jonasbn)
-2004-2018
+2004-2019
 
 Date-Holidays and related modules are released under the Artistic License 2.0
 

--- a/lib/Date/Holidays/Adapter/GB.pm
+++ b/lib/Date/Holidays/Adapter/GB.pm
@@ -6,7 +6,7 @@ use vars qw($VERSION);
 
 use base 'Date::Holidays::Adapter';
 
-$VERSION = '1.16';
+$VERSION = '1.17';
 
 sub holidays {
     my ($self, %params) = @_;
@@ -48,7 +48,7 @@ Date::Holidays::Adapter::GB - an adapter class for Date::Holidays::GB
 
 =head1 VERSION
 
-This POD describes version 1.16 of Date::Holidays::Adapter::GB
+This POD describes version 1.17 of Date::Holidays::Adapter::GB
 
 =head1 DESCRIPTION
 
@@ -110,7 +110,7 @@ Jonas B. Nielsen, (jonasbn) - C<< <jonasbn@cpan.org> >>
 =head1 LICENSE AND COPYRIGHT
 
 L<Date::Holidays> and related modules are (C) by Jonas B. Nielsen, (jonasbn)
-2004-2018
+2004-2019
 
 Date-Holidays and related modules are released under the Artistic License 2.0
 

--- a/lib/Date/Holidays/Adapter/JP.pm
+++ b/lib/Date/Holidays/Adapter/JP.pm
@@ -8,7 +8,7 @@ use Carp;
 
 use base 'Date::Holidays::Adapter';
 
-$VERSION = '1.16';
+$VERSION = '1.17';
 
 sub holidays {
     croak "holidays is unimplemented for ".__PACKAGE__;
@@ -60,7 +60,7 @@ Date::Holidays::Adapter::JP - an adapter class for Date::Japanese::Holiday
 
 =head1 VERSION
 
-This POD describes version 1.16 of Date::Holidays::Adapter::JP
+This POD describes version 1.17 of Date::Holidays::Adapter::JP
 
 =head1 DESCRIPTION
 
@@ -137,7 +137,7 @@ Jonas B. Nielsen, (jonasbn) - C<< <jonasbn@cpan.org> >>
 =head1 LICENSE AND COPYRIGHT
 
 L<Date::Holidays> and related modules are (C) by Jonas B. Nielsen, (jonasbn)
-2004-2018
+2004-2019
 
 Date-Holidays and related modules are released under the Artistic License 2.0
 

--- a/lib/Date/Holidays/Adapter/KR.pm
+++ b/lib/Date/Holidays/Adapter/KR.pm
@@ -7,7 +7,7 @@ use Carp;
 
 use base 'Date::Holidays::Adapter';
 
-$VERSION = '1.16';
+$VERSION = '1.17';
 
 sub holidays {
     croak "holidays is unimplemented for ".__PACKAGE__;
@@ -37,7 +37,7 @@ Date::Holidays::Adapter::KR - an adapter class for Date::Holidays::KR
 
 =head1 VERSION
 
-This POD describes version 1.16 of Date::Holidays::Adapter::KR
+This POD describes version 1.17 of Date::Holidays::Adapter::KR
 
 =head1 DESCRIPTION
 
@@ -100,7 +100,7 @@ Jonas B. Nielsen, (jonasbn) - C<< <jonasbn@cpan.org> >>
 =head1 LICENSE AND COPYRIGHT
 
 L<Date::Holidays> and related modules are (C) by Jonas B. Nielsen, (jonasbn)
-2004-2018
+2004-2019
 
 Date-Holidays and related modules are released under the Artistic License 2.0
 

--- a/lib/Date/Holidays/Adapter/KZ.pm
+++ b/lib/Date/Holidays/Adapter/KZ.pm
@@ -6,7 +6,7 @@ use vars qw($VERSION);
 
 use base 'Date::Holidays::Adapter';
 
-$VERSION = '1.16';
+$VERSION = '1.17';
 
 sub holidays {
     my ($self, %params) = @_;
@@ -48,7 +48,7 @@ Date::Holidays::Adapter::KZ - an adapter class for Date::Holidays::KZ
 
 =head1 VERSION
 
-This POD describes version 1.16 of Date::Holidays::Adapter::KZ
+This POD describes version 1.17 of Date::Holidays::Adapter::KZ
 
 =head1 DESCRIPTION
 
@@ -110,7 +110,7 @@ Jonas B. Nielsen, (jonasbn) - C<< <jonasbn@cpan.org> >>
 =head1 LICENSE AND COPYRIGHT
 
 L<Date::Holidays> and related modules are (C) by Jonas B. Nielsen, (jonasbn)
-2004-2018
+2004-2019
 
 Date-Holidays and related modules are released under the Artistic License 2.0
 

--- a/lib/Date/Holidays/Adapter/Local.pm
+++ b/lib/Date/Holidays/Adapter/Local.pm
@@ -7,7 +7,7 @@ use JSON; #from_json
 use Env qw($HOLIDAYS_FILE);
 use vars qw($VERSION);
 
-$VERSION = '1.16';
+$VERSION = '1.17';
 
 sub new {
     my $class = shift;
@@ -103,7 +103,7 @@ Date::Holidays::Adapter::Local - a specialized adapter for local calendars
 
 =head1 VERSION
 
-This POD describes version 1.16 of Date::Holidays::Adapter::Local
+This POD describes version 1.17 of Date::Holidays::Adapter::Local
 
 =head1 SYNOPSIS
 
@@ -212,7 +212,7 @@ Jonas B. Nielsen, (jonasbn) - C<< <jonasbn@cpan.org> >>
 =head1 LICENSE AND COPYRIGHT
 
 L<Date::Holidays> and related modules are (C) by Jonas B. Nielsen, (jonasbn)
-2004-2018
+2004-2019
 
 L<Date::Holidays> and related modules are released under the Artistic License 2.0
 

--- a/lib/Date/Holidays/Adapter/NO.pm
+++ b/lib/Date/Holidays/Adapter/NO.pm
@@ -6,7 +6,7 @@ use base 'Date::Holidays::Adapter';
 
 use vars qw($VERSION);
 
-$VERSION = '1.16';
+$VERSION = '1.17';
 
 sub holidays {
     my ($self, %params) = @_;
@@ -44,7 +44,7 @@ Date::Holidays::Adapter::NO - an adapter class for Date::Holidays::NO
 
 =head1 VERSION
 
-This POD describes version 1.16 of Date::Holidays::Adapter::NO
+This POD describes version 1.17 of Date::Holidays::Adapter::NO
 
 =head1 SUBROUTINES/METHODS
 
@@ -102,7 +102,7 @@ Jonas B. Nielsen, (jonasbn) - C<< <jonasbn@cpan.org> >>
 =head1 LICENSE AND COPYRIGHT
 
 L<Date::Holidays> and related modules are (C) by Jonas B. Nielsen, (jonasbn)
-2004-2018
+2004-2019
 
 Date-Holidays and related modules are released under the Artistic License 2.0
 

--- a/lib/Date/Holidays/Adapter/NZ.pm
+++ b/lib/Date/Holidays/Adapter/NZ.pm
@@ -6,7 +6,7 @@ use vars qw($VERSION);
 
 use base 'Date::Holidays::Adapter';
 
-$VERSION = '1.16';
+$VERSION = '1.17';
 
 sub holidays {
     my ($self, %params) = @_;
@@ -48,7 +48,7 @@ Date::Holidays::Adapter::NZ - an adapter class for Date::Holidays::NZ
 
 =head1 VERSION
 
-This POD describes version 1.16 of Date::Holidays::Adapter::NZ
+This POD describes version 1.17 of Date::Holidays::Adapter::NZ
 
 =head1 DESCRIPTION
 
@@ -114,7 +114,7 @@ Jonas B. Nielsen, (jonasbn) - C<< <jonasbn@cpan.org> >>
 =head1 LICENSE AND COPYRIGHT
 
 L<Date::Holidays> and related modules are (C) by Jonas B. Nielsen, (jonasbn)
-2004-2018
+2004-2019
 
 Date-Holidays and related modules are released under the Artistic License 2.0
 

--- a/lib/Date/Holidays/Adapter/PL.pm
+++ b/lib/Date/Holidays/Adapter/PL.pm
@@ -7,7 +7,7 @@ use Carp;
 
 use base 'Date::Holidays::Adapter';
 
-$VERSION = '1.16';
+$VERSION = '1.17';
 
 sub holidays {
     croak "holidays is unimplemented for ".__PACKAGE__;
@@ -37,7 +37,7 @@ Date::Holidays::Adapter::PL - an adapter class for Date::Holidays::PL
 
 =head1 VERSION
 
-This POD describes version 1.16 of Date::Holidays::Adapter::PL
+This POD describes version 1.17 of Date::Holidays::Adapter::PL
 
 =head1 DESCRIPTION
 
@@ -99,7 +99,7 @@ Jonas B. Nielsen, (jonasbn) - C<< <jonasbn@cpan.org> >>
 =head1 LICENSE AND COPYRIGHT
 
 L<Date::Holidays> and related modules are (C) by Jonas B. Nielsen, (jonasbn)
-2004-2018
+2004-2019
 
 Date-Holidays and related modules are released under the Artistic License 2.0
 

--- a/lib/Date/Holidays/Adapter/PT.pm
+++ b/lib/Date/Holidays/Adapter/PT.pm
@@ -7,7 +7,7 @@ use base 'Date::Holidays::Adapter';
 
 use vars qw($VERSION);
 
-$VERSION = '1.16';
+$VERSION = '1.17';
 
 sub holidays {
     my ($self, %params) = @_;
@@ -45,7 +45,7 @@ Date::Holidays::Adapter::PT - an adapter class for Date::Holidays::PT
 
 =head1 VERSION
 
-This POD describes version 1.16 of Date::Holidays::Adapter::PT
+This POD describes version 1.17 of Date::Holidays::Adapter::PT
 
 =head1 DESCRIPTION
 
@@ -109,7 +109,7 @@ Jonas B. Nielsen, (jonasbn) - C<< <jonasbn@cpan.org> >>
 =head1 LICENSE AND COPYRIGHT
 
 L<Date::Holidays> and related modules are (C) by Jonas B. Nielsen, (jonasbn)
-2004-2018
+2004-2019
 
 Date-Holidays and related modules are released under the Artistic License 2.0
 

--- a/lib/Date/Holidays/Adapter/RU.pm
+++ b/lib/Date/Holidays/Adapter/RU.pm
@@ -6,7 +6,7 @@ use vars qw($VERSION);
 
 use base 'Date::Holidays::Adapter';
 
-$VERSION = '1.16';
+$VERSION = '1.17';
 
 sub holidays {
     my ($self, %params) = @_;
@@ -48,7 +48,7 @@ Date::Holidays::Adapter::RU - an adapter class for Date::Holidays::RU
 
 =head1 VERSION
 
-This POD describes version 1.16 of Date::Holidays::Adapter::RU
+This POD describes version 1.17 of Date::Holidays::Adapter::RU
 
 =head1 DESCRIPTION
 
@@ -110,7 +110,7 @@ Jonas B. Nielsen, (jonasbn) - C<< <jonasbn@cpan.org> >>
 =head1 LICENSE AND COPYRIGHT
 
 L<Date::Holidays> and related modules are (C) by Jonas B. Nielsen, (jonasbn)
-2004-2018
+2004-2019
 
 Date-Holidays and related modules are released under the Artistic License 2.0
 

--- a/lib/Date/Holidays/Adapter/SK.pm
+++ b/lib/Date/Holidays/Adapter/SK.pm
@@ -6,7 +6,7 @@ use vars qw($VERSION);
 
 use base 'Date::Holidays::Adapter';
 
-$VERSION = '1.16';
+$VERSION = '1.17';
 
 sub holidays {
     my ($self, %params) = @_;
@@ -48,7 +48,7 @@ Date::Holidays::Adapter::SK - an adapter class for Date::Holidays::SK
 
 =head1 VERSION
 
-This POD describes version 1.16 of Date::Holidays::Adapter::SK
+This POD describes version 1.17 of Date::Holidays::Adapter::SK
 
 =head1 DESCRIPTION
 
@@ -110,7 +110,7 @@ Jonas B. Nielsen, (jonasbn) - C<< <jonasbn@cpan.org> >>
 =head1 LICENSE AND COPYRIGHT
 
 L<Date::Holidays> and related modules are (C) by Jonas B. Nielsen, (jonasbn)
-2004-2018
+2004-2019
 
 Date-Holidays and related modules are released under the Artistic License 2.0
 

--- a/lib/Date/Holidays/Adapter/UK.pm
+++ b/lib/Date/Holidays/Adapter/UK.pm
@@ -7,7 +7,7 @@ use base qw(Date::Holidays::Adapter::GB);
 
 use vars qw($VERSION);
 
-$VERSION = '1.16';
+$VERSION = '1.17';
 
 1;
 
@@ -21,7 +21,7 @@ Date::Holidays::Adapter::UK - adapter dummy class for Date::Holidays::UK
 
 =head1 VERSION
 
-This POD describes version 1.16 of Date::Holidays::Adapter::UK
+This POD describes version 1.17 of Date::Holidays::Adapter::UK
 
 =head1 DESCRIPTION
 
@@ -74,7 +74,7 @@ Jonas B. Nielsen, (jonasbn) - C<< <jonasbn@cpan.org> >>
 =head1 LICENSE AND COPYRIGHT
 
 L<Date::Holidays> and related modules are (C) by Jonas B. Nielsen, (jonasbn)
-2004-2018
+2004-2019
 
 Date-Holidays and related modules are released under the Artistic License 2.0
 

--- a/lib/Date/Holidays/Adapter/US.pm
+++ b/lib/Date/Holidays/Adapter/US.pm
@@ -8,7 +8,7 @@ use Data::Dumper;
 
 use base 'Date::Holidays::Adapter';
 
-$VERSION = '1.16';
+$VERSION = '1.17';
 
 sub holidays {
     croak "holidays is unimplemented for ".__PACKAGE__;
@@ -36,7 +36,7 @@ Date::Holidays::Adapter::US - an adapter class for Date::Holidays::USFederal
 
 =head1 VERSION
 
-This POD describes version 1.16 of Date::Holidays::Adapter::US
+This POD describes version 1.17 of Date::Holidays::Adapter::US
 
 =head1 DESCRIPTION
 
@@ -92,7 +92,7 @@ Jonas B. Nielsen, (jonasbn) - C<< <jonasbn@cpan.org> >>
 =head1 LICENSE AND COPYRIGHT
 
 L<Date::Holidays> and related modules are (C) by Jonas B. Nielsen, (jonasbn)
-2004-2018
+2004-2019
 
 Date-Holidays and related modules are released under the Artistic License 2.0
 

--- a/lib/Date/Holidays/Adapter/USFederal.pm
+++ b/lib/Date/Holidays/Adapter/USFederal.pm
@@ -8,7 +8,7 @@ use Data::Dumper;
 
 use base 'Date::Holidays::Adapter';
 
-$VERSION = '1.16';
+$VERSION = '1.17';
 
 # sub new {
 #     my $class = shift;
@@ -44,7 +44,7 @@ Date::Holidays::Adapter::USFederal - an adapter class for Date::Holidays::USFede
 
 =head1 VERSION
 
-This POD describes version 1.16 of Date::Holidays::Adapter::USFederal
+This POD describes version 1.17 of Date::Holidays::Adapter::USFederal
 
 =head1 DESCRIPTION
 
@@ -100,7 +100,7 @@ Jonas B. Nielsen, (jonasbn) - C<< <jonasbn@cpan.org> >>
 =head1 LICENSE AND COPYRIGHT
 
 L<Date::Holidays> and related modules are (C) by Jonas B. Nielsen, (jonasbn)
-2004-2018
+2004-2019
 
 Date-Holidays and related modules are released under the Artistic License 2.0
 

--- a/prototypes/de.pl
+++ b/prototypes/de.pl
@@ -2,15 +2,20 @@
 
 use lib qw(blib/lib);
 use Date::Holidays;
+use Data::Dumper;
 
 my $dh = Date::Holidays->new(
 			countrycode => 'de'
 		);
 
-$dh->holidays(year => 2005);
+my $holidays = $dh->holidays( year => 2018, state => ['bb', 'sl']);
 
-use Data::Dumper;
-use Date::Holidays::DE;
-my $holidays = Date::Holidays::DE::holidays();
+print STDERR Dumper $holidays;
+
+$holidays = $dh->holidays( year => 2018,);
+
+print STDERR Dumper $holidays;
+
+$holidays = $dh->holidays( state => ['bb'] );
 
 print STDERR Dumper $holidays;


### PR DESCRIPTION
# Description

As requested in issue #31 Date::Holidays::DE also support state, but Date::Holidays does not propagate this parameter. With this PR is does.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project, please see the [contribution guidelines](https://github.com/jonasbn/perl-date-holidays/blob/master/CONTRIBUTING.md).
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules

You might think, that this is one crazy checklist, but it is just as much written for the maintainer of the involved software :-)

Oh yes, since the test suite is being rewritten, I skipped the test implementation, have run tests manually though.
