### PR TITLE
Load the CA_ES sub-module from is_holiday function

### DIFF
--- a/lib/Date/Holidays/Adapter/ES.pm
+++ b/lib/Date/Holidays/Adapter/ES.pm
@@ -49,7 +49,15 @@ sub is_holiday {
     my $dh = $self->{_adaptee}->new();
 
     if ($dh) {
+        my $holiday = $dh->is_holiday(year => $params{year}, month => $params{month}, day => $params{day});
+
         if ($params{region} and $params{region} eq 'ca') {
+
+            eval { load 'Date::Holidays::CA_ES'; }; # From Module::Load
+            if ($@) {
+                warn "Unable to load: Date::Holidays::CA_ES - $@\n";
+                return $holiday;
+            }
 
             my $dh_ca_es = Date::Holidays::CA_ES->new();
 
@@ -57,7 +65,7 @@ sub is_holiday {
 
             my $holiday_date = sprintf('%02s%02s', $params{month}, $params{day});
 
-            my $holiday = $holidays->{$holiday_date};
+            $holiday = $holidays->{$holiday_date};
 
             if ($holiday) {
                 return $holiday;
@@ -66,7 +74,7 @@ sub is_holiday {
             }
         }
 
-        return $dh->is_holiday(year => $params{year}, month => $params{month}, day => $params{day});
+        return $holiday
     } else {
         return '';
     }


### PR DESCRIPTION
# Description

The CA_ES sub-module was not being loaded via Module::Load from `is_holiday` inside Adapter/ES.pm
Fixes https://github.com/miquelruiz/Date-Holidays-CA_ES/issues/2. The broken tests in there pass with this change applied.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project, please see the [contribution guidelines](https://github.com/jonasbn/perl-date-holidays/blob/master/CONTRIBUTING.md).
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

