### PR TITLE
Addressing issue 47, by specifying required version for Test::MockModule

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 Changes file for Date-Holidays
 
+1.28 2020-11-11 Maintenance release, update not required
+
+- We need to specify the requirement of Test::MockModule to version 0.13, since redefined not introduced until this version
+
 1.27 2020-11-09 Bug fix release, update recommended
 
 - Fixed a bug in the mock introduced in release 1.27. Had added it to the cpanfile, but not the proper prerequisites and the mocking was not correct syntax

--- a/dist.ini
+++ b/dist.ini
@@ -81,4 +81,4 @@ Test::Kwalitee          = 1.21 ; from Dist::Zilla
 Pod::Coverage::TrustPod = 0    ; from Dist::Zilla
 Test::Pod               = 1.41 ; from Dist::Zilla
 Test::Pod::Coverage     = 1.08 ; from Dist::Zilla
-Test::MockModule        = 0
+Test::MockModule        = 0.13

--- a/lib/Date/Holidays.pm
+++ b/lib/Date/Holidays.pm
@@ -11,7 +11,7 @@ use Scalar::Util qw(blessed);
 
 use base 'Date::Holidays::Adapter';
 
-$VERSION = '1.27';
+$VERSION = '1.28';
 
 sub new {
     my ( $class, %params ) = @_;

--- a/lib/Date/Holidays/Adapter.pm
+++ b/lib/Date/Holidays/Adapter.pm
@@ -10,7 +10,7 @@ use Scalar::Util qw(blessed);
 
 use vars qw($VERSION);
 
-$VERSION = '1.27';
+$VERSION = '1.28';
 
 sub new {
     my ($class, %params) = @_;

--- a/lib/Date/Holidays/Adapter/AT.pm
+++ b/lib/Date/Holidays/Adapter/AT.pm
@@ -10,7 +10,7 @@ use vars qw($VERSION);
 
 my $format = '%#:%m%d';
 
-$VERSION = '1.27';
+$VERSION = '1.28';
 
 # Lifted from Date::Holidays::AT source code
 # Ref: https://metacpan.org/source/MDIETRICH/Date-Holidays-AT-v0.1.4/lib/Date/Holidays/AT.pm

--- a/lib/Date/Holidays/Adapter/AU.pm
+++ b/lib/Date/Holidays/Adapter/AU.pm
@@ -6,7 +6,7 @@ use vars qw($VERSION);
 
 use base 'Date::Holidays::Adapter';
 
-$VERSION = '1.27';
+$VERSION = '1.28';
 
 use constant DEFAULT_STATE => 'VIC';
 

--- a/lib/Date/Holidays/Adapter/AW.pm
+++ b/lib/Date/Holidays/Adapter/AW.pm
@@ -6,7 +6,7 @@ use vars qw($VERSION);
 
 use base 'Date::Holidays::Adapter';
 
-$VERSION = '1.27';
+$VERSION = '1.28';
 
 sub holidays {
     my ($self, %params) = @_;

--- a/lib/Date/Holidays/Adapter/BR.pm
+++ b/lib/Date/Holidays/Adapter/BR.pm
@@ -7,7 +7,7 @@ use base 'Date::Holidays::Adapter';
 
 use vars qw($VERSION);
 
-$VERSION = '1.27';
+$VERSION = '1.28';
 
 sub holidays {
     my ( $self, %params ) = @_;

--- a/lib/Date/Holidays/Adapter/BY.pm
+++ b/lib/Date/Holidays/Adapter/BY.pm
@@ -6,7 +6,7 @@ use vars qw($VERSION);
 
 use base 'Date::Holidays::Adapter';
 
-$VERSION = '1.27';
+$VERSION = '1.28';
 
 sub holidays {
     my ($self, %params) = @_;

--- a/lib/Date/Holidays/Adapter/CA_ES.pm
+++ b/lib/Date/Holidays/Adapter/CA_ES.pm
@@ -7,7 +7,7 @@ use base qw(Date::Holidays::Adapter::ES);
 
 use vars qw($VERSION);
 
-$VERSION = '1.27';
+$VERSION = '1.28';
 
 1;
 

--- a/lib/Date/Holidays/Adapter/CN.pm
+++ b/lib/Date/Holidays/Adapter/CN.pm
@@ -7,7 +7,7 @@ use base 'Date::Holidays::Adapter';
 
 use vars qw($VERSION);
 
-$VERSION = '1.27';
+$VERSION = '1.28';
 
 sub holidays {
     my ($self, %params) = @_;

--- a/lib/Date/Holidays/Adapter/CZ.pm
+++ b/lib/Date/Holidays/Adapter/CZ.pm
@@ -7,7 +7,7 @@ use base 'Date::Holidays::Adapter';
 
 use vars qw($VERSION);
 
-$VERSION = '1.27';
+$VERSION = '1.28';
 
 my $format = '%#:%m%d';
 

--- a/lib/Date/Holidays/Adapter/DE.pm
+++ b/lib/Date/Holidays/Adapter/DE.pm
@@ -10,7 +10,7 @@ use vars qw($VERSION);
 
 my $format = '%#:%m%d';
 
-$VERSION = '1.27';
+$VERSION = '1.28';
 
 # Lifted from Date::Holidays::DE example: feiertage.pl
 # Ref: https://metacpan.org/source/MSCHMITT/Date-Holidays-DE-1.9/example/feiertage.pl

--- a/lib/Date/Holidays/Adapter/DK.pm
+++ b/lib/Date/Holidays/Adapter/DK.pm
@@ -6,7 +6,7 @@ use vars qw($VERSION);
 
 use base 'Date::Holidays::Adapter';
 
-$VERSION = '1.27';
+$VERSION = '1.28';
 
 sub holidays {
     my ($self, %params) = @_;

--- a/lib/Date/Holidays/Adapter/ES.pm
+++ b/lib/Date/Holidays/Adapter/ES.pm
@@ -8,7 +8,7 @@ use Module::Load; # load
 
 use vars qw($VERSION);
 
-$VERSION = '1.27';
+$VERSION = '1.28';
 
 sub holidays {
     my ($self, %params) = @_;

--- a/lib/Date/Holidays/Adapter/FR.pm
+++ b/lib/Date/Holidays/Adapter/FR.pm
@@ -7,7 +7,7 @@ use Carp;
 
 use base 'Date::Holidays::Adapter';
 
-$VERSION = '1.27';
+$VERSION = '1.28';
 
 sub holidays {
     croak "holidays is unimplemented for ".__PACKAGE__;

--- a/lib/Date/Holidays/Adapter/GB.pm
+++ b/lib/Date/Holidays/Adapter/GB.pm
@@ -6,7 +6,7 @@ use vars qw($VERSION);
 
 use base 'Date::Holidays::Adapter';
 
-$VERSION = '1.27';
+$VERSION = '1.28';
 
 sub holidays {
     my ($self, %params) = @_;

--- a/lib/Date/Holidays/Adapter/JP.pm
+++ b/lib/Date/Holidays/Adapter/JP.pm
@@ -8,7 +8,7 @@ use Carp;
 
 use base 'Date::Holidays::Adapter';
 
-$VERSION = '1.27';
+$VERSION = '1.28';
 
 sub holidays {
     croak "holidays is unimplemented for ".__PACKAGE__;

--- a/lib/Date/Holidays/Adapter/KR.pm
+++ b/lib/Date/Holidays/Adapter/KR.pm
@@ -7,7 +7,7 @@ use Carp;
 
 use base 'Date::Holidays::Adapter';
 
-$VERSION = '1.27';
+$VERSION = '1.28';
 
 sub holidays {
     croak "holidays is unimplemented for ".__PACKAGE__;

--- a/lib/Date/Holidays/Adapter/KZ.pm
+++ b/lib/Date/Holidays/Adapter/KZ.pm
@@ -6,7 +6,7 @@ use vars qw($VERSION);
 
 use base 'Date::Holidays::Adapter';
 
-$VERSION = '1.27';
+$VERSION = '1.28';
 
 sub holidays {
     my ($self, %params) = @_;

--- a/lib/Date/Holidays/Adapter/Local.pm
+++ b/lib/Date/Holidays/Adapter/Local.pm
@@ -7,7 +7,7 @@ use JSON; #from_json
 use Env qw($HOLIDAYS_FILE);
 use vars qw($VERSION);
 
-$VERSION = '1.27';
+$VERSION = '1.28';
 
 sub new {
     my $class = shift;

--- a/lib/Date/Holidays/Adapter/NL.pm
+++ b/lib/Date/Holidays/Adapter/NL.pm
@@ -6,7 +6,7 @@ use vars qw($VERSION);
 
 use base 'Date::Holidays::Adapter';
 
-$VERSION = '1.27';
+$VERSION = '1.28';
 
 sub holidays {
     my ($self, %params) = @_;

--- a/lib/Date/Holidays/Adapter/NO.pm
+++ b/lib/Date/Holidays/Adapter/NO.pm
@@ -6,7 +6,7 @@ use base 'Date::Holidays::Adapter';
 
 use vars qw($VERSION);
 
-$VERSION = '1.27';
+$VERSION = '1.28';
 
 sub holidays {
     my ($self, %params) = @_;

--- a/lib/Date/Holidays/Adapter/NZ.pm
+++ b/lib/Date/Holidays/Adapter/NZ.pm
@@ -6,7 +6,7 @@ use vars qw($VERSION);
 
 use base 'Date::Holidays::Adapter';
 
-$VERSION = '1.27';
+$VERSION = '1.28';
 
 sub holidays {
     my ($self, %params) = @_;

--- a/lib/Date/Holidays/Adapter/PL.pm
+++ b/lib/Date/Holidays/Adapter/PL.pm
@@ -7,7 +7,7 @@ use Carp;
 
 use base 'Date::Holidays::Adapter';
 
-$VERSION = '1.27';
+$VERSION = '1.28';
 
 sub holidays {
     croak "holidays is unimplemented for ".__PACKAGE__;

--- a/lib/Date/Holidays/Adapter/PT.pm
+++ b/lib/Date/Holidays/Adapter/PT.pm
@@ -7,7 +7,7 @@ use base 'Date::Holidays::Adapter';
 
 use vars qw($VERSION);
 
-$VERSION = '1.27';
+$VERSION = '1.28';
 
 sub holidays {
     my ($self, %params) = @_;

--- a/lib/Date/Holidays/Adapter/RU.pm
+++ b/lib/Date/Holidays/Adapter/RU.pm
@@ -6,7 +6,7 @@ use vars qw($VERSION);
 
 use base 'Date::Holidays::Adapter';
 
-$VERSION = '1.27';
+$VERSION = '1.28';
 
 sub holidays {
     my ($self, %params) = @_;

--- a/lib/Date/Holidays/Adapter/SK.pm
+++ b/lib/Date/Holidays/Adapter/SK.pm
@@ -6,7 +6,7 @@ use vars qw($VERSION);
 
 use base 'Date::Holidays::Adapter';
 
-$VERSION = '1.27';
+$VERSION = '1.28';
 
 sub holidays {
     my ($self, %params) = @_;

--- a/lib/Date/Holidays/Adapter/UA.pm
+++ b/lib/Date/Holidays/Adapter/UA.pm
@@ -7,7 +7,7 @@ use Carp;
 
 use base 'Date::Holidays::Adapter';
 
-$VERSION = '1.27';
+$VERSION = '1.28';
 
 sub holidays {
     my ($self, %params) = @_;

--- a/lib/Date/Holidays/Adapter/UK.pm
+++ b/lib/Date/Holidays/Adapter/UK.pm
@@ -7,7 +7,7 @@ use base qw(Date::Holidays::Adapter::GB);
 
 use vars qw($VERSION);
 
-$VERSION = '1.27';
+$VERSION = '1.28';
 
 1;
 

--- a/lib/Date/Holidays/Adapter/US.pm
+++ b/lib/Date/Holidays/Adapter/US.pm
@@ -8,7 +8,7 @@ use Data::Dumper;
 
 use base 'Date::Holidays::Adapter';
 
-$VERSION = '1.27';
+$VERSION = '1.28';
 
 sub holidays {
     croak "holidays is unimplemented for ".__PACKAGE__;

--- a/lib/Date/Holidays/Adapter/USFederal.pm
+++ b/lib/Date/Holidays/Adapter/USFederal.pm
@@ -8,7 +8,7 @@ use Data::Dumper;
 
 use base 'Date::Holidays::Adapter';
 
-$VERSION = '1.27';
+$VERSION = '1.28';
 
 # sub new {
 #     my $class = shift;


### PR DESCRIPTION
# Description

Specified minimum requirement for Test::MockModule to 0.13, which introduces `redefine`.

CPAN-testers using 0.11, emit failure reports

This closes #47 

This should be labelled as a maintenance release, since the update is not required for all. 

## Bug fix 

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project, please see the [contribution guidelines](https://github.com/jonasbn/perl-date-holidays/blob/master/CONTRIBUTING.md).
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes

You might think, that this is one crazy checklist, but it is just as much written for the maintainer of the involved software :-)
