### PR TITLE
remove extraneous arguments to use and use_ok

### DIFF
--- a/t/Test/Class/Date/Holidays/Produceral.pm
+++ b/t/Test/Class/Date/Holidays/Produceral.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use base qw(Test::Class);
 use Test::More;
-use Date::Holidays::Produceral qw(holidays is_holiday);
+use Date::Holidays::Produceral;
 
 our $VERSION = '1.34';
 
@@ -22,7 +22,7 @@ sub test_produceral_interface : Test(13) {
 
     # bare
 
-    use_ok('Date::Holidays::Produceral', qw(holidays is_holiday));
+    use_ok('Date::Holidays::Produceral');
 
     can_ok('Date::Holidays::Produceral', qw(holidays is_holiday));
 


### PR DESCRIPTION
# Description

The Date::Holidays::Produceral module does not export anything and has no import method, so passing arguments to it serves no purpose.

These arguments were ignored by perl, but future versions are intending to throw errors for arguments passed to an undefined import method.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project, please see the [contribution guidelines](https://github.com/jonasbn/perl-date-holidays/blob/master/CONTRIBUTING.md).
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
